### PR TITLE
EMAIL ENDPOINT 

### DIFF
--- a/BUG_FIX_591.md
+++ b/BUG_FIX_591.md
@@ -1,0 +1,31 @@
+# Bug Fix #591: Auth email endpoints crash due to missing `next`
+
+## Issue
+`/auth/check-email` and `/auth/register` used handlers shaped like:
+
+- `asyncHandler(async (req, res) => { ... return next(new AppError(...)) })`
+
+Because `next` was not part of the function signature, validation error paths threw:
+
+- `ReferenceError: next is not defined`
+
+This caused unintended `500` responses instead of structured validation errors.
+
+## Root Cause
+The route handlers called `next(...)` without declaring `next` as a parameter.
+
+## Fix Applied
+Updated both route handler signatures in `backend/routes/auth.js`:
+
+- `asyncHandler(async (req, res) => {` → `asyncHandler(async (req, res, next) => {`
+
+### Affected endpoints
+- `POST /api/auth/check-email`
+- `POST /api/auth/register`
+
+## Expected Behavior After Fix
+Validation failures now properly flow to the global error handler and return expected `4xx` responses instead of crashing with `ReferenceError` and returning `500`.
+
+## Verification Notes
+- Static verification: changed file compiles with no editor-reported errors.
+- Runtime test command was attempted but local backend test dependencies were missing (`jest` not installed in `backend/node_modules`).

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -141,7 +141,7 @@ router.post(
       .withMessage("Please provide a valid email")
       .normalizeEmail(),
   ],
-  asyncHandler(async (req, res) => {
+  asyncHandler(async (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return next(new AppError(400, "Invalid email format", errors.array()));
@@ -242,7 +242,7 @@ router.post(
       .isLength({ min: 1, max: 50 })
       .withMessage("Last name is required and must be less than 50 characters"),
   ],
-  asyncHandler(async (req, res) => {
+  asyncHandler(async (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return next(new AppError(400, "Validation failed", errors.array()));


### PR DESCRIPTION


## Summary
This PR fixes a runtime error in auth validation paths where `next(new AppError(...))` was called without `next` being declared in the handler signature.

Because of that, invalid requests to email-related auth endpoints could return `500` with `ReferenceError: next is not defined` instead of structured `4xx` validation responses.

## Root Cause
Handlers were defined as:

- `asyncHandler(async (req, res) => { ... next(...) ... })`

`next` was referenced but not included in the function parameters.

## Changes
Updated handler signatures to include `next` in:

- `POST /api/auth/check-email`
- `POST /api/auth/register`

File updated:

- `backend/routes/auth.js`

Also added documentation for this fix:

- `BUG_FIX_591.md`

## Behavior Before
- Validation failures could throw `ReferenceError: next is not defined`
- Endpoint returned unintended `500`

## Behavior After
- Validation failures are forwarded to global error middleware
- Endpoints return expected structured `4xx` responses (`400`/`409` as applicable)

## Verification
- Static verification: no editor-reported errors in modified file.
- Runtime test command attempted: `npm test -- __tests__/routes/auth.test.js`
- Note: local backend test dependencies were missing (`backend/node_modules/jest`), so runtime verification is pending dependency install.

## Related Issue
- Closes #591
